### PR TITLE
fix(components): use cdn for deps instead of npm specifier

### DIFF
--- a/packages/components/scripts/build_npm.ts
+++ b/packages/components/scripts/build_npm.ts
@@ -27,11 +27,11 @@ await build({
       name: "zod",
       version: "^3.0.0",
     },
-    "npm:qs@6.x": {
+    "https://esm.sh/qs@6.x": {
       name: "qs",
       version: "^6.0.0",
     },
-    "npm:devalue@4.x": {
+    "https://esm.sh/devalue@4.x": {
       name: "devalue",
       version: "^4.0.0",
     },

--- a/packages/components/src/deps/devalue.ts
+++ b/packages/components/src/deps/devalue.ts
@@ -1,1 +1,1 @@
-export * from "npm:devalue@4.x";
+export * from "https://esm.sh/devalue@4.x";

--- a/packages/components/src/deps/qs.ts
+++ b/packages/components/src/deps/qs.ts
@@ -1,2 +1,2 @@
-// @deno-types="npm:@types/qs@6.x"
-export { parse, stringify } from "npm:qs@6.x";
+// @deno-types="https://esm.sh/@types/qs@6.x"
+export { parse, stringify } from "https://esm.sh/qs@6.x";


### PR DESCRIPTION
Deno Deploy does not support npm specifiers at the moment